### PR TITLE
ansys-templates edits to doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,18 @@
 Welcome to PyAnsys Templates
 ============================
 
-The ``PyAnsys Templates`` holds a collection of useful templates compliant with
-the PyAnsys guidelines. It provides the ``ansys-templates`` command line tool
+The ``pyansys-templates`` repository holds a collection of useful templates compliant
+with PyAnsys guidelines. It also provides the ``ansys-templates`` command line tool
 for interactively generating new projects based on previous templates.
 
-Main advantages of using this tool are:
+The main advantages of using this tool are:
 
-- Building process is fully interactive: no need to manually modifying files!
-- Customize output project during rendering process.
+- Building process is fully interactive. There is no need to manually modify files.
+- Output of the project can easily be customized during the rendering process.
 - Generated projects are compliant with `PyAnsys Developer's Guidelines`_.
 
 .. _PyAnsys Developer's Guidelines: https://dev.docs.pyansys.com/
 
-To use this tool, reference its documentation at `PyAnsys Template Documentation`_.
+For information on using this tool, see the `PyAnsys Template Documentation`_.
 
 .. _PyAnsys Template Documentation: https://templates.pyansys.com/ 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 Welcome to Ansys Templates
-============================
+==========================
 
 The ``ansys-templates`` repository holds a collection of useful templates compliant
 with PyAnsys guidelines. It also provides the ``ansys-templates`` command line tool

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
-Welcome to PyAnsys Templates
+Welcome to Ansys Templates
 ============================
 
-The ``pyansys-templates`` repository holds a collection of useful templates compliant
+The ``ansys-templates`` repository holds a collection of useful templates compliant
 with PyAnsys guidelines. It also provides the ``ansys-templates`` command line tool
 for interactively generating new projects based on previous templates.
 
@@ -13,6 +13,6 @@ The main advantages of using this tool are:
 
 .. _PyAnsys Developer's Guidelines: https://dev.docs.pyansys.com/
 
-For information on using this tool, see the `PyAnsys Template Documentation`_.
+For information on using this tool, see the `Ansys Templates Documentation`_.
 
 .. _PyAnsys Template Documentation: https://templates.pyansys.com/ 

--- a/README.rst
+++ b/README.rst
@@ -15,4 +15,4 @@ The main advantages of using this tool are:
 
 For information on using this tool, see the `Ansys Templates Documentation`_.
 
-.. _PyAnsys Template Documentation: https://templates.pyansys.com/ 
+.. _Ansys Templates Documentation: https://templates.pyansys.com/ 

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -23,7 +23,7 @@ Upgrade `pip`_ with:
    python -m pip install --upgrade pip
 
 
-Installing Pipx
+Installing ``pipx``
 ^^^^^^^^^^^^^^^
  
 The ``ansys-templates`` tool is built on top of Python. To ensure a clean

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -3,14 +3,14 @@
 Getting Started
 ===============
 
-To successfully install ``pyansys-templates``, carefully read all instructions on this page.
+To successfully install ``ansys-templates``, carefully read all instructions on this page.
 
 
 Before Installing
 -----------------
 
 Several requirements must be met before you install
-``pyansys-templates``.
+``ansys-templates``.
 
 
 Upgrading ``pip``
@@ -46,21 +46,21 @@ If you encounter any issues when installing `pipx`_, see `pipx installation
 guidelines`_.
 
 
-Installing PyAnsys Templates
+Installing ``ansys-templates``
 ----------------------------
 
 Once `pipx`_ is installed, proceed with the installation of
-``pyansys-templates`` with:
+``ansys-templates`` with:
 
 .. code:: bash
 
-   python -m pipx install pyansys-templates
+   python -m pipx install ansys-templates
 
 
-Upgrading PyAnsys Templates
+Upgrading ``ansys-templates``
 ---------------------------
 
-If you already have ``pyansys-templates`` installed with `pipx`_, you can upgrade
+If you already have ``ansys-templates`` installed with `pipx`_, you can upgrade
 to the latest version with:
 
 .. code:: bash
@@ -75,13 +75,13 @@ Once installed, you can verify your installation with:
 
 .. code:: bash
 
-   pyansys-templates --help
+   ansys-templates --help
 
 The following code is returned:
 
 .. code:: text
 
-   Usage: pyansys-templates [OPTIONS] COMMAND [ARGS]...
+   Usage: ansys-templates [OPTIONS] COMMAND [ARGS]...
 
    Ansys tool for creating Python projects.
    

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -3,7 +3,7 @@
 Getting Started
 ===============
 
-To successfully install ``pyansysansys-templates``, carefully read all instructions on this page.
+To successfully install ``pyansys-templates``, carefully read all instructions on this page.
 
 
 Before Installing

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -47,7 +47,7 @@ guidelines`_.
 
 
 Installing ``ansys-templates``
-----------------------------
+------------------------------
 
 Once `pipx`_ is installed, proceed with the installation of
 ``ansys-templates`` with:
@@ -58,7 +58,7 @@ Once `pipx`_ is installed, proceed with the installation of
 
 
 Upgrading ``ansys-templates``
----------------------------
+-----------------------------
 
 If you already have ``ansys-templates`` installed with `pipx`_, you can upgrade
 to the latest version with:

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -3,65 +3,65 @@
 Getting Started
 ===============
 
-Please, carefully read all the instructions in this page in order to achieve a
-successfully install of ``ansys-templates``.
+To successfully install ``pyansysansys-templates``, read all instructions on this page carefully.
 
 
 Before Installing
 -----------------
 
-Several requirements need to be fulfilled before you can proceed installing
-``ansys-templates`` tool.
+Several requirements must be met before you install
+``pyansys-templates``.
 
 
-Upgrading pip
+Upgrading Pip
 ^^^^^^^^^^^^^
 
-Before installing the ``ansys-templates``, it is advisable to upgrade `pip`_ by
-running:
+Upgrade `pip`_ with:
 
 .. code:: bash
 
    python -m pip install --upgrade pip
 
 
-Installing pipx
+Installing Pipx
 ^^^^^^^^^^^^^^^
  
 The ``ansys-templates`` tool is built on top of Python. To ensure a clean
-installation you can use `pipx`_. This tool ensures an isolated installation of
-any Python tool you want to use. You can install it by running:
+installation, you can use `pipx`_. It ensures an isolated installation of
+any Python tool that you want to use. 
+
+Install `pipx`_ with:
 
 .. code:: bash
 
    python -m pip install --user pipx
 
-Ensure that `pipx`_ is in your ``PATH`` by running:
+Ensure that `pipx`_ is in your ``PATH`` with:
 
 .. code:: bash
 
    python -m pipx ensurepath
 
-If you encounter any issues when installing `pipx`_, refer to `pipx installation
+If you encounter any issues when installing `pipx`_, see `pipx installation
 guidelines`_.
 
 
-Installing ansys-templates
---------------------------
+Installing PyAnsys Templates
+----------------------------
 
-Once you have installed `pipx`_, proceed with the installation of
-``ansys-templates`` by running:
+Once `pipx`_ is installed, proceed with the installation of
+``pyansys-templates`` with:
 
 .. code:: bash
 
    python -m pipx install pyansys-templates
 
 
-Upgrading ansys-templates
--------------------------
+Upgrading PyAnsys Templates
+---------------------------
 
-If you already have ``ansys-templates`` installed with `pipx`_, you can upgrade
-to the latest version by running:
+If you already have ``pyansys-templates`` installed with `pipx`_, you can upgrade
+to the latest version with:
 
 .. code:: bash
 
@@ -71,17 +71,17 @@ to the latest version by running:
 Verify Your Installation
 ------------------------
 
-Once installed, you can verify your installation by running:
+Once installed, you can verify your installation with:
 
 .. code:: bash
 
-   ansys-templates --help
+   pyansys-templates --help
 
-Which returns:
+The following code is returned:
 
 .. code:: text
 
-   Usage: ansys-templates [OPTIONS] COMMAND [ARGS]...
+   Usage: pyansys-templates [OPTIONS] COMMAND [ARGS]...
 
    Ansys tool for creating Python projects.
    

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -14,7 +14,7 @@ Several requirements must be met before you install
 
 
 Upgrading ``pip``
-^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
 
 Upgrade `pip`_ with:
 

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -13,7 +13,7 @@ Several requirements must be met before you install
 ``pyansys-templates``.
 
 
-Upgrading Pip
+Upgrading ``pip``
 ^^^^^^^^^^^^^
 
 Upgrade `pip`_ with:

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -24,7 +24,7 @@ Upgrade `pip`_ with:
 
 
 Installing ``pipx``
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^
  
 The ``ansys-templates`` tool is built on top of Python. To ensure a clean
 installation, you can use `pipx`_. It ensures an isolated installation of

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -1,8 +1,8 @@
-User guide
+User Guide
 ==========
 
-This page contains various guides explaining how to use ``ansys-templates`` and
-contribute to the tool by adding new templates.
+This section explains how to use ``pyansys-templates`` and
+contribute by adding new templates.
 
 .. toctree::
 

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -1,7 +1,7 @@
 User Guide
 ==========
 
-This section explains how to use ``pyansys-templates`` and
+This section explains how to use ``ansys-templates`` and
 contribute by adding new templates.
 
 .. toctree::

--- a/doc/source/user_guide/templating.rst
+++ b/doc/source/user_guide/templating.rst
@@ -201,7 +201,7 @@ Removing Undesired Files
 ------------------------
 
 It is likely that there are some files coming from the ``common/``
-directory that you do not want included in your rendered template. To exlude files,
+directory that you do not want included in your rendered template. To exclude files,
 you can take advantage of `cookiecutter hooks`_. 
 
 Hooks are Python scripts that allow you to control the rendering process both before

--- a/doc/source/user_guide/templating.rst
+++ b/doc/source/user_guide/templating.rst
@@ -1,24 +1,23 @@
 How to Add a New Template
 =========================
 
-You can easily add new templates to ``ansys-templates``. Before adding a new
-template, it is important that you read the CONTRIBUTING section.
+You can easily add new PyAnsys templates. However, before doing so, it is important that
+you read the CONTRIBUTING section.
 
 
 Understanding the Templates Directory
 -------------------------------------
 
-All ``ansys-templates`` are collected inside the ``templates/`` directory, which
-is included in the ``src/``. The ``templates/`` directory holds different
-families of templates.
+In ``pyansys-templates``, all templates are placed in ``src/ansys/templates/``.
+The ``templates/`` directory contains different families of templates.
 
-A ``family of templates`` is just a directory holding a ``common/`` folder and
-various ``templates/``:
+A `family of templates` is simply a directory with a ``common/`` folder and
+various templates folders.
 
-- The ``common/`` directory contains various resources which are common to all
+- The ``common/`` folder contains various resources that are common to all
   templates of a given family. This avoids duplication of files across templates.
 
-- Each ``template/`` contains its own custom files.
+- Each template folder contains its own set of custom files.
 
 .. code:: bash
 
@@ -45,14 +44,14 @@ various ``templates/``:
 
 
 Be sure to check if there is already a family for the template you want
-to add or you need to create one.
+to add before creating a new one.
 
 
-Adding a New family of Templates
+Adding a New Family of Templates
 --------------------------------
 
 Start by creating a new directory in ``src/ansys/templates/`` with the name of
-the new family of templates. For example, let's name it ``src/ansys/templates/new_family``:
+the new family of templates. For example, create ``src/ansys/templates/new_family``:
 
 .. code:: bash
 
@@ -64,29 +63,28 @@ the new family of templates. For example, let's name it ``src/ansys/templates/ne
           └── {{cookiecutter.__project_name_slug}}/
               └── ... # All these files will be included in each family template
 
-Inside this new family, you will need to create at least two different files:
+Inside this new family, you must create at least two different files:
 
 - A ``cookiecutter.json`` file for specifying the minimum required variables for
-  any of the templates of the family to work. You must use cookiecutter private
-  variables in here.
+  any of this family's templates to work. You must use cookie cutter private
+  variables in this file.
 
-- A ``common/{{cookiecutter.__project_name_slug}}/`` directory. This directory
-  contains all the typical files for a given family. All files in the
-  ``common/{{cookiecutter.__project_name_slug}}`` directory will be copied to
-  each template when rendering it.
+- A ``common/{{cookiecutter.__project_name_slug}}/`` directory to contain all of
+the typical files for this family. All files in the ``common/{{cookiecutter.__project_name_slug}}``
+directory will be copied to each template when rendering it.
   
 .. note::
 
     You can later add a ``hooks/post_gen_project.py`` file in the
-    ``family/template/`` directory for removing non-desired files coming from
+    ``family/template/`` directory if you need to remove non-desired files coming from
     the ``common/{{cookiecutter.__project_name_slug}}`` directory.
 
 
 Adding a New Template to a Family
 ---------------------------------
 
-To add a new template, start by creating a new template folder. For example, let's
-name it ``src/ansys/templates/family_0/new_template``:
+To add a new template to a fmaily, first create a new template folder. For example,
+``src/ansys/templates/family_0/new_template``:
 
 .. code:: bash
 
@@ -102,29 +100,29 @@ name it ``src/ansys/templates/family_0/new_template``:
            └── {{cookiecutter.__project_name_slug}}/
                └── ... # Custom template files
 
-Inside the ``new_template/``, you will need to create at least two different files:
+Inside the ``new_template/`` directory, you must create at least two different files:
 
-- A ``cookiecutter.json`` file for specifying the new template variables. You
-  must override the ``common/cookiecutter.json`` variables too!
+- A ``cookiecutter.json`` file for specifying variables for the new template and
+  overriding ``common/cookiecutter.json`` variables.
 
-- A ``{{cookiecutter.__project_name_slug}}/`` directory. This directory must
-  contain any additional files or directories you would like to include in your
-  new template. Notice this folder will be combined with the
-  ``common/{{cookiecutter.__project_name_slug}}/`` one.
+- A ``{{cookiecutter.__project_name_slug}}/`` directory to contain any additional files or
+  directories that you would like to include in your new template. The files in this directory
+  will be combined with the files in the  ``common/{{cookiecutter.__project_name_slug}}/``
+  directory.
 
 
-Adding it to the CLI
-^^^^^^^^^^^^^^^^^^^^
+Adding a New Template to the CLI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To have access to the template from the CLI (command line interface), you will
-need to:
+To have access to a newly template from the CLI (command line interface), you must do
+the following:
 
-1. Include the named and description of the new template in the
+1. Include the name and description of the new template in the
    ``src/ansys/templates/__init__.py`` file under the
    ``AVAILABLE_TEMPLATES_AND_DESCRIPTION`` dictionary.
 
-2. Add the path to the new template in ``src/ansys/templates/paths.py``. Include
-   it in the ``TEMPLATE_PATH_FINDER`` dictionary too.
+2. Add the path to the new template in ``src/ansys/templates/paths.py`` and in
+   the ``TEMPLATE_PATH_FINDER`` dictionary.
 
 3. Create a command to expose the new template in the CLI:
 
@@ -139,8 +137,8 @@ need to:
 Adding Unit Tests
 """""""""""""""""
 
-Each template must have its own unit test script. The following namespace is
-followed in order to organize the test suite:
+Each template must have its own unit test script. To organize the test suite,
+the following namespace is followed:
 
 - ``tests/tests_templates_family/test_template_family_name_of_template.py``
 
@@ -149,9 +147,9 @@ followed in order to organize the test suite:
    If you created a new family template, make sure to include tests for the
    ``family/common/`` directory too.
 
-Expected common files should be included under a
-``tests/tests_templates_family/conftest.py`` as a `pytest fixture`_. For
-example, consider the following code of a generic ``conftest.py`` file:
+Expected common files should be defined in ``tests/tests_templates_family/conftest.py``
+as a `pytest fixture`_. For example, consider the following code of a generic ``conftest.py``
+file:
 
 .. code:: python
 
@@ -163,7 +161,7 @@ example, consider the following code of a generic ``conftest.py`` file:
         doc_files = [...]
         tests_files = [...]
 
-        # Combine all files and export those to be accessible by the tests
+        # Combine all files and export those to be accessible to the tests
         all_common_files = basedir_files + doc_files + tests_files
         return all_common_files
 
@@ -171,7 +169,7 @@ example, consider the following code of a generic ``conftest.py`` file:
 Add the Family to Tox envs
 """"""""""""""""""""""""""
 
-If you created a new family, make sure to add it to the [tox] set of
+If you created a new family, you must add it to the [tox] set of
 environments:
 
 1. Look for the ``[testenv]`` section in the ``tox.ini`` file.
@@ -187,29 +185,30 @@ Updating the CI
 """""""""""""""
 
 Each family of templates is tested within its own `GitHub actions`_ workflow.
-Therefore, you need to create a:
+Therefore, you need to create a YML file for a new family:
 
 - ``.github/workflows/templates_family.yml``
 
 .. note::
 
    To reduce the amount of CI jobs, templates are only tested under Linux.
-   If you require from any particular programming language, try to test the
-   minimum and maximum supported versions/standards of the language. Avoid all
-   the intermediate ones if possible.
+   If you require testing from a particular programming language, try to test the
+   minimum and maximum supported versions of the language. Avoid all intermediate
+   versions if possible.
 
 
 Removing Undesired Files
 ------------------------
 
-It is likely that you do not want some files coming from the ``common/``
-directory to be included in your rendered template. You can take advantage of 
-`cookiecutter hooks`_. 
+It is likely that there are some files coming from the ``common/``
+directory that you do not want included in your rendered template. To exlude files,
+you can take advantage of `cookiecutter hooks`_. 
 
-Hooks are Python scripts which allow you to control the rendering process before
-and after it has been executed. This way you can move or delete any files
-included in the final rendered project. In order to use hooks, you need to
-create a new directory named ``src/ansys/templates/new_family/new_template/hooks``.
+Hooks are Python scripts that allow you to control the rendering process both before
+and after the process is executed. With hooks, you can move or delete any files
+included in the final rendered project.
+
+To use hooks, you must create a new directory named ``src/ansys/templates/new_family/new_template/hooks``.
 Only two hooks are allowed:
 
 - ``pre_gen_project.py``: executes before rendering process.
@@ -217,9 +216,9 @@ Only two hooks are allowed:
 
 .. warning::
 
-   Both hooks are executed once cookiecutter context has been started. This
-   implies that any file with a variable of the type {{ cookiecutter.some_var }}
-   or Jinja2 syntax will not be rendered!
+   Both hooks are executed once the cookie cutter context has been started. This
+   implies that any file with a variable of the type ``{{ cookiecutter.some_var }}``
+   or Jinja2 syntax will not be rendered.
 
 
 .. REFERENCES & LINKS

--- a/doc/source/user_guide/templating.rst
+++ b/doc/source/user_guide/templating.rst
@@ -70,8 +70,9 @@ Inside this new family, you must create at least two different files:
   variables in this file.
 
 - A ``common/{{cookiecutter.__project_name_slug}}/`` directory to contain all of
-the typical files for this family. All files in the ``common/{{cookiecutter.__project_name_slug}}``
-directory will be copied to each template when rendering it.
+  the typical files for this family. All files in the ``common/{{cookiecutter.__project_name_slug}}``
+  directory will be copied to each template when rendering it.
+  
   
 .. note::
 

--- a/doc/source/user_guide/templating.rst
+++ b/doc/source/user_guide/templating.rst
@@ -1,14 +1,14 @@
 How to Add a New Template
 =========================
 
-You can easily add new PyAnsys templates. However, before doing so, it is important that
-you read the CONTRIBUTING section.
+You can easily add new templates. However, before doing so, it is important that
+you read the Contributing section.
 
 
 Understanding the Templates Directory
 -------------------------------------
 
-In ``pyansys-templates``, all templates are placed in ``src/ansys/templates/``.
+In ``ansys-templates``, all templates are placed in ``src/ansys/templates/``.
 The ``templates/`` directory contains different families of templates.
 
 A `family of templates` is simply a directory with a ``common/`` folder and
@@ -84,7 +84,7 @@ Inside this new family, you must create at least two different files:
 Adding a New Template to a Family
 ---------------------------------
 
-To add a new template to a fmaily, first create a new template folder. For example,
+To add a new template to a family, first create a new template folder. For example,
 ``src/ansys/templates/family_0/new_template``:
 
 .. code:: bash
@@ -217,7 +217,7 @@ Only two hooks are allowed:
 
 .. warning::
 
-   Both hooks are executed once the cookie cutter context has been started. This
+   Both hooks are executed once the cookiecutter context has been started. This
    implies that any file with a variable of the type ``{{ cookiecutter.some_var }}``
    or Jinja2 syntax will not be rendered.
 

--- a/doc/source/user_guide/usage.rst
+++ b/doc/source/user_guide/usage.rst
@@ -2,7 +2,7 @@
 
 
 How to Use ``ansys-templates``
-============================
+==============================
 
 Because ``ansys-templates`` is a command line tool, its usage is intended via
 the command line. You can check available commands with:
@@ -64,7 +64,7 @@ For example, to create a new Python Package project with the pybasic template:
 
    ansys-templates new pybasic
 
-You can see all templates available with ``pyansys-templates list``. Or, see more
+You can see all templates available with ``ansys-templates list``. Or, see more
 information about how to use this command with:
 
 .. code:: bash

--- a/doc/source/user_guide/usage.rst
+++ b/doc/source/user_guide/usage.rst
@@ -1,21 +1,21 @@
 .. _ref_user_guide:
 
 
-How to Use PyAnsys Templates
+How to Use ``ansys-templates``
 ============================
 
-Because ``pyansys-templates`` is a command line tool, its usage is intended via
+Because ``ansys-templates`` is a command line tool, its usage is intended via
 the command line. You can check available commands with:
 
 .. code:: bash
 
-   pyansys-templates --help
+   ansys-templates --help
 
 The following help content is returned:
 
 .. code:: text
 
-   Usage: pyansys-templates [OPTIONS] COMMAND [ARGS]...
+   Usage: ansys-templates [OPTIONS] COMMAND [ARGS]...
 
    Ansys tool for creating Python projects.
    
@@ -41,7 +41,7 @@ The following templates are returned:
 
 .. code:: text
 
-   Available templates in pyansys-templates are:
+   Available templates in ``ansys-templates`` are:
 
    pybasic: Create a basic Python Package.
    pyansys: Create a PyAnsys Python Package project.
@@ -56,20 +56,20 @@ new`` followed by the name of the template that you want to use:
 
 .. code:: bash
 
-   pyansys-templates new <template_name>
+   ansys-templates new <template_name>
 
 For example, to create a new Python Package project with the pybasic template:
 
 .. code:: bash
 
-   pyansys-templates new pybasic
+   ansys-templates new pybasic
 
 You can see all templates available with ``pyansys-templates list``. Or, see more
 information about how to use this command with:
 
 .. code:: bash
 
-   pyansys-templates new --help
+   ansys-templates new --help
 
 Checking the Current Version
 ----------------------------
@@ -78,4 +78,4 @@ Check the your current installed version of PyAnsys templates with:
 
 .. code:: bash
 
-   pyansys-templates version
+   ansys-templates version

--- a/doc/source/user_guide/usage.rst
+++ b/doc/source/user_guide/usage.rst
@@ -1,21 +1,21 @@
 .. _ref_user_guide:
 
 
-How to Use ansys-templates
-==========================
+How to Use PyAnsys Templates
+============================
 
-Because ``ansys-templates`` is a command line tool, its usage is intended via
-the command line. You can check available commands by running:
+Because ``pyansys-templates`` is a command line tool, its usage is intended via
+the command line. You can check available commands with:
 
 .. code:: bash
 
-   ansys-templates --help
+   pyansys-templates --help
 
-Which returns:
+The following help content is returned:
 
 .. code:: text
 
-   Usage: ansys-templates [OPTIONS] COMMAND [ARGS]...
+   Usage: pyansys-templates [OPTIONS] COMMAND [ARGS]...
 
    Ansys tool for creating Python projects.
    
@@ -28,57 +28,54 @@ Which returns:
      version  Display current version.
 
 
-Listing Available Templates
----------------------------
+Listing All Templates
+---------------------
 
-You can list all available templates by running:
+You can list all templates with:
 
 .. code:: bash
 
    ansys-templates list
 
-Which outputs:
+The following templates are returned:
 
 .. code:: text
 
-   Available templates in ansys-templates are:
+   Available templates in pyansys-templates are:
 
    pybasic: Create a basic Python Package.
    pyansys: Create a PyAnsys Python Package project.
    pyansys_advanced: Create an advanced PyAnsys Python Package project.
 
 
-Creating a New Project
-----------------------
+Creating a New PyAnsys Project
+------------------------------
 
-You can create a new project using a given template by running ``ansys-templates
-new`` and passing the name of the template you wish to use.
-
-.. code:: bash
-
-   ansys-templates new <template_name>
-
-For example, to create a new Python Package project, use:
+You can use a given template to create a new PyAnsys project with ``ansys-templates
+new`` followed by the name of the template that you want to use:
 
 .. code:: bash
 
-   ansys-templates new pybasic
+   pyansys-templates new <template_name>
 
-Check available templates names using ``ansys-templates list`` command or just
-run:
-
-.. code:: bash
-
-   ansys-templates new --help
-
-for further information about how to use this command.
-
-
-Checking Current Version
-------------------------
-
-For checking the your current installed version of ``ansys-templates`` simply run:
+For example, to create a new Python Package project with the pybasic template:
 
 .. code:: bash
 
-   ansys-templates version
+   pyansys-templates new pybasic
+
+You can see all templates available with ``pyansys-templates list``. Or, see more
+information about how to use this command with:
+
+.. code:: bash
+
+   pyansys-templates new --help
+
+Checking the Current Version
+----------------------------
+
+Check the your current installed version of PyAnsys templates with:
+
+.. code:: bash
+
+   pyansys-templates version


### PR DESCRIPTION
Kelly Fletcher tried to use this doc to set up a PyAnsys project for NSV doc and had problems because ansys-templates was noted instead of pyansys-templates. She also couldn't use pipx. I'll add a comment in the file to better explain.