### PR TITLE
Update black pre-commit to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
     args: [

--- a/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/.pre-commit-config.yaml
+++ b/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
     args: [


### PR DESCRIPTION
Addresses the error: `ImportError: cannot import name '_unicodefun' from 'click' (/home/plule/.cache/pre-commit/repoxu2gx_m_/py_env-python3.8/lib/python3.8/site-packages/click/__init__.py)`

See: https://github.com/psf/black/issues/2964