### PR TITLE
Fix Python templates metadata

### DIFF
--- a/src/ansys/templates/python/pyansys/cookiecutter.json
+++ b/src/ansys/templates/python/pyansys/cookiecutter.json
@@ -9,6 +9,7 @@
   "version": "0.1.dev0",
   "__version": "{{ cookiecutter.version }}",
   "short_description": "A Python wrapper for Ansys {{ cookiecutter.product_name }} {{ cookiecutter.library_name }}",
+  "__short_description": "{{ cookiecutter.short_description | capitalize }}",
   "repository_url": "https://github.com/pyansys/{{ cookiecutter.__project_name_slug }}",
   "__repository_url": "{{ cookiecutter.repository_url }}",
   "requires_python": ["3.7", "3.8", "3.9", "3.10"],

--- a/src/ansys/templates/python/pyansys/{{cookiecutter.__project_name_slug}}/setup.py
+++ b/src/ansys/templates/python/pyansys/{{cookiecutter.__project_name_slug}}/setup.py
@@ -1,9 +1,25 @@
-from setuptools import setup, find_packages
+from setuptools import find_namespace_packages, setup
 
 setup(
     name="{{ cookiecutter.__pkg_name }}",
     version="{{ cookiecutter.__version }}",
-    description="{{ cookiecutter.short_description }}",
-    packages=find_packages(where="src"),
+    url="{{ cookiecutter.__repository_url }}",
+    author="ANSYS, Inc.",
+    author_email="pyansys.support@ansys.com",
+    maintainer="PyAnsys developers",
+    maintainer_email="pyansys.maintainers@ansys.com",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    license="MIT",
+    license_file=LICENSE,
+    description="{{ cookiecutter.__short_description }}",
+    long_description=open("README.rst").read(),
+    install_requires=["importlib-metadata >=4.0"],
+    python_requires=">={{ cookiecutter.__requires_python }}",
+    packages=find_namespace_packages(where="src", include="ansys*"),
     package_dir={"": "src"},
 )

--- a/src/ansys/templates/python/pyansys/{{cookiecutter.__project_name_slug}}/setup.py
+++ b/src/ansys/templates/python/pyansys/{{cookiecutter.__project_name_slug}}/setup.py
@@ -15,7 +15,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     license="MIT",
-    license_file=LICENSE,
+    license_file="LICENSE",
     description="{{ cookiecutter.__short_description }}",
     long_description=open("README.rst").read(),
     install_requires=["importlib-metadata >=4.0"],

--- a/src/ansys/templates/python/pyansys_advanced/cookiecutter.json
+++ b/src/ansys/templates/python/pyansys_advanced/cookiecutter.json
@@ -10,6 +10,7 @@
   "version": "0.1.dev0",
   "__version": "{{ cookiecutter.version }}",
   "short_description": "A Python wrapper for Ansys {{ cookiecutter.product_name }} {{ cookiecutter.library_name }}",
+  "__short_description": "{{ cookiecutter.short_description | capitalize }}",
   "repository_url": "https://github.com/pyansys/{{ cookiecutter.__project_name_slug }}",
   "__repository_url": "{{ cookiecutter.repository_url }}",
   "requires_python": ["3.7", "3.8", "3.9", "3.10"],

--- a/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/pyproject_flit.toml
+++ b/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/pyproject_flit.toml
@@ -5,10 +5,10 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "{{ cookiecutter.__pkg_name }}"
-version = "{{ cookiecutter.version }}"
-description = "{{ cookiecutter.short_description }}"
+version = "{{ cookiecutter.__version }}"
+description = "{{ cookiecutter.__short_description }}"
 readme = "README.rst"
-requires-python = ">={{ cookiecutter.requires_python }}"
+requires-python = ">={{ cookiecutter.__requires_python }}"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.support@ansys.com"},
@@ -31,4 +31,4 @@ dependencies = [
 name = "{{ cookiecutter.__pkg_namespace }}"
 
 [project.urls]
-Source = "{{ cookiecutter.repository_url }}"
+Source = "{{ cookiecutter.__repository_url }}"

--- a/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/pyproject_poetry.toml
+++ b/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/pyproject_poetry.toml
@@ -5,13 +5,13 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 # Check https://python-poetry.org/docs/pyproject/ for all available sections
 name = "{{ cookiecutter.__pkg_name }}"
-version = "{{ cookiecutter.version }}"
-description = "{{ cookiecutter.short_description }}"
+version = "{{ cookiecutter.__version }}"
+description = "{{ cookiecutter.__short_description }}"
 license = "MIT"
 authors = ["ANSYS, Inc. <ansys.support@ansys.com>"]
 maintainers = ["PyAnsys developers <pyansys.maintainers@ansys.com>"]
 readme = "README.rst"
-repository = "{{ cookiecutter.repository_url }}"
+repository = "{{ cookiecutter.__repository_url }}"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
@@ -23,5 +23,5 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">={{ cookiecutter.requires_python }},<4.0"
+python = ">={{ cookiecutter.__requires_python }},<4.0"
 importlib-metadata = {version = "^4.0", python = "<3.8"}

--- a/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/setup_setuptools.py
+++ b/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/setup_setuptools.py
@@ -1,22 +1,25 @@
-"""Installation file for ansys-mapdl-core."""
-
 from setuptools import find_namespace_packages, setup
 
 setup(
     name="{{ cookiecutter.__pkg_name }}",
-    packages=find_namespace_packages(where="src", include="ansys*"),
-    package_dir={"": "src"},
-    version="{{ cookiecutter.version }}",
-    description="{{ cookiecutter.short_description }}",
-    long_description=open("README.rst").read(),
-    license="MIT",
+    version="{{ cookiecutter.__version }}",
+    url="{{ cookiecutter.__repository_url }}",
+    author="ANSYS, Inc.",
+    author_email="pyansys.support@ansys.com",
+    maintainer="PyAnsys developers",
+    maintainer_email="pyansys.maintainers@ansys.com",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    url="{{ cookiecutter.repository_url }}",
-    python_requires=">={{ cookiecutter.requires_python }}",
+    license="MIT",
+    license_file=LICENSE,
+    description="{{ cookiecutter.__short_description }}",
+    long_description=open("README.rst").read(),
     install_requires=["importlib-metadata >=4.0"],
+    python_requires=">={{ cookiecutter.__requires_python }}",
+    packages=find_namespace_packages(where="src", include="ansys*"),
+    package_dir={"": "src"},
 )

--- a/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/setup_setuptools.py
+++ b/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/setup_setuptools.py
@@ -15,7 +15,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     license="MIT",
-    license_file=LICENSE,
+    license_file="LICENSE",
     description="{{ cookiecutter.__short_description }}",
     long_description=open("README.rst").read(),
     install_requires=["importlib-metadata >=4.0"],

--- a/src/ansys/templates/python/pybasic/cookiecutter.json
+++ b/src/ansys/templates/python/pybasic/cookiecutter.json
@@ -4,7 +4,7 @@
   "version": "0.1.dev0",
   "__version": "{{ cookiecutter.version }}",
   "short_description": "",
-  "__short_description": "{{ cookiecutter.short_description }}",
+  "__short_description": "{{ cookiecutter.short_description | capitalize }}",
   "__pkg_name": "{{ cookiecutter.__project_name_slug | replace('_', '-')}}",
   "__pkg_namespace": "{{ cookiecutter.__project_name_slug }}",
   "requires_python": ["3.7", "3.8", "3.9", "3.10"],

--- a/src/ansys/templates/python/pybasic/{{cookiecutter.__project_name_slug}}/setup.py
+++ b/src/ansys/templates/python/pybasic/{{cookiecutter.__project_name_slug}}/setup.py
@@ -3,7 +3,23 @@ from setuptools import setup, find_packages
 setup(
     name="{{ cookiecutter.__pkg_name }}",
     version="{{ cookiecutter.__version }}",
+    url="{{ cookiecutter.__repository_url }}",
+    author="ANSYS, Inc.",
+    author_email="pyansys.support@ansys.com",
+    maintainer="PyAnsys developers",
+    maintainer_email="pyansys.maintainers@ansys.com",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    license="MIT",
+    license_file=LICENSE,
     description="{{ cookiecutter.__short_description }}",
+    long_description=open("README.rst").read(),
+    install_requires=["importlib-metadata >=4.0"],
+    python_requires=">={{ cookiecutter.__requires_python }}",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
 )

--- a/src/ansys/templates/python/pybasic/{{cookiecutter.__project_name_slug}}/setup.py
+++ b/src/ansys/templates/python/pybasic/{{cookiecutter.__project_name_slug}}/setup.py
@@ -15,7 +15,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     license="MIT",
-    license_file=LICENSE,
+    license_file="LICENSE",
     description="{{ cookiecutter.__short_description }}",
     long_description=open("README.rst").read(),
     install_requires=["importlib-metadata >=4.0"],


### PR DESCRIPTION
Resolves #42 by adding the required metadata. Small enhancements to private variables have been made too.

The order in the `setup.py` files is the one specified in the [declarative configuration](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#declarative-config) from the Setuptools guidelines.