### PR TITLE
Move style tools config to pyproject.toml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,0 @@
-[run]
-source =
-    ansys/templates
-omit = 
-    ansys/templates/python/*
-
-[report]
-show_missing = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,26 +4,11 @@ repos:
   rev: 22.3.0
   hooks:
   - id: black
-    args: [
-      --force-exclude, src/ansys/templates/python,
-      --line-length, "100",
-      src, tests
-    ]
 
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1
   hooks:
   - id: isort
-    exclude: ^src/ansys/templates/pypkg/
-    args: [
-      --profile, black,
-      --force-sort-within-sections,
-      --line-length, "100",
-      --section-default, THIRDPARTY, 
-      --skip-glob, src/ansys/templates/python/*, 
-      --filter-files,
-      tests, doc
-    ]
 
 - repo: https://gitlab.com/PyCQA/flake8
   rev: 4.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,23 @@ ansys-templates = "ansys.templates.cli:main"
 
 [project.urls]
 Source = "https://github.com/pyansys/pyansys-template"
+
+[tool.black]
+force-exclude = ["src/ansys/templates/python"]
+line-length = "100"
+
+[tool.isort]
+profile = "black"
+force_sort_within_sections = true
+line_length = "100"
+default_section = "THIRDPARTY"
+skip_glob = ["src/ansys/templates/python/*"] 
+filter_files = "true"
+src_paths = ["doc", "src", "tests"]
+
+[tool.coverage.run]
+source = ["ansys/templates"]
+omit = ["ansys/templates/python/*"]
+
+[tool.coverage.report]
+show_missing = true

--- a/src/ansys/templates/python/pyansys_advanced/hooks/post_gen_project.py
+++ b/src/ansys/templates/python/pyansys_advanced/hooks/post_gen_project.py
@@ -22,6 +22,10 @@ def main():
         setup_file = project_path / "setup.py"
         setup_file.unlink()
 
+    # Remove .coveragerc as its content is specified in the pyproject.toml
+    coveragerc_file = project_path / ".coveragerc"
+    coveragerc_file.unlink()
+
     # Move all requirements files into a requirements/ directory
     os.mkdir(project_path / "requirements")
     requirements_files = [

--- a/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/.pre-commit-config.yaml
+++ b/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/.pre-commit-config.yaml
@@ -4,28 +4,16 @@ repos:
   rev: 22.3.0
   hooks:
   - id: black
-    args: [
-      --line-length, "{{ cookiecutter.__max_linelength }}",
-      src, tests
-    ]
 
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1
   hooks:
   - id: isort
-    args: [
-      --profile, black,
-      --force-sort-within-sections,
-      --line-length, "{{ cookiecutter.__max_linelength }}",
-      --section-default, THIRDPARTY,
-      src, tests, doc
-    ]
 
 - repo: https://gitlab.com/PyCQA/flake8
   rev: 4.0.1
   hooks:
   - id: flake8
-    args: [src, tests, doc]
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.1.0
@@ -37,5 +25,3 @@ repos:
   hooks:
   - id: pydocstyle
     additional_dependencies: [toml]
-    args: ["--match-dir='^(src)'"]
-    exclude: "^(tests/)"

--- a/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/pyproject.toml
+++ b/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/pyproject.toml
@@ -65,4 +65,23 @@ packages = [
 [tool.poetry.dependencies]
 python = ">={{ cookiecutter.__requires_python }},<4.0"
 importlib-metadata = {version = "^4.0", python = "<3.8"}
-{% endif -%}
+{% endif %}
+[tool.black]
+line-length = {{ cookiecutter.__max_linelength }}
+
+[tool.isort]
+profile = "black"
+force_sort_within_sections = true
+line_length = {{ cookiecutter.__max_linelength }}
+default_section = "THIRDPARTY"
+src_paths = ["doc", "src", "tests"]
+
+[tool.pydocstyle]
+match-dir = "^(src)"
+exclude = "^(tests/)"
+
+[tool.coverage.run]
+source = ["ansys.{{ cookiecutter.__product_name_slug }}"]
+
+[tool.coverage.report]
+show_missing = true


### PR DESCRIPTION
Partially solves for #50.

* **Migrated tools:** black, isort, coverage and pydocstyle
* **Lacking of PEP 518 support:** flake8, codespell