### PR TITLE
Add breadcrumbs

### DIFF
--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/source/conf.py
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/source/conf.py
@@ -14,10 +14,16 @@ release = version = __version__
 html_logo = pyansys_logo_black
 html_theme = "pyansys_sphinx_theme"
 
+html_short_title = html_title = "{{ cookiecutter.__pkg_name }}"
+
 # specify the location of your github repo
 html_theme_options = {
     "github_url": "{{ cookiecutter.__repository_url }}",
     "show_prev_next": False,
+    "show_breadcrumbs": True,
+    "additional_breadcrumbs": [
+        ("PyAnsys", "https://docs.pyansys.com/"),
+    ],
 }
 
 # Sphinx extensions


### PR DESCRIPTION
Documentation: add breadcrumbs.

This adds the line "PyAnsys >> MyPackage >> Current Page" in the header, as seen in [pymapdldoc](https://mapdldocs.pyansys.com/getting_started/index.htmlhttps://mapdldocs.pyansys.com/getting_started/index.html) and others

Note: I'm not familiar enough with the stack to verify this change locally, I only applied the same in an already existing repo