### PR TITLE
Fix pydocstyle config pyansys-advanced

### DIFF
--- a/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/pyproject.toml
+++ b/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/pyproject.toml
@@ -76,10 +76,6 @@ line_length = {{ cookiecutter.__max_linelength }}
 default_section = "THIRDPARTY"
 src_paths = ["doc", "src", "tests"]
 
-[tool.pydocstyle]
-match-dir = "^(src)"
-exclude = "^(tests/)"
-
 [tool.coverage.run]
 source = ["ansys.{{ cookiecutter.__product_name_slug }}"]
 


### PR DESCRIPTION
Fixes a bug I introduced in #53. The "pydocstyle" tool has no "exclude" flag. Also, it ignores tests by default.