### PR TITLE
Enable codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
       - name: Run Tox
         run: tox -e ${{ matrix.cfg.toxenv }}-smoke-cov
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        if: matrix.cfg.python-version == '3.7'
+
   build:
     name: Build package
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enables coverage report upload to [Codecov], as it happens with other public PyAnsys projects.

[Codecov]: https://app.codecov.io/