### PR TITLE
Suggest grpc intersphinx

### DIFF
--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/source/conf.py
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/source/conf.py
@@ -44,6 +44,7 @@ intersphinx_mapping = {
     # "matplotlib": ("https://matplotlib.org/stable", None),
     # "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
     # "pyvista": ("https://docs.pyvista.org/", None),
+    # "grpc": ("https://grpc.github.io/grpc/python/", None),
 }
 
 # numpydoc configuration


### PR DESCRIPTION
The grpc python documentation can be used to generated links when exposing grpc objects. Given how widely we are using it, I think it's worth adding it to the suggested intersphinx_mapping list