### PR TITLE
Add a non-versionned python tox environment

### DIFF
--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/tox.ini
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/tox.ini
@@ -25,6 +25,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py: python3
     {%- if cookiecutter.__build_system != "poetry" %}
     {style,reformat,doc,build}: python3
     {%- else -%}

--- a/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/README.rst
+++ b/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/README.rst
@@ -146,8 +146,8 @@ own virtual environment so anything being tested is isolated from the project in
 order to guarantee project's integrity. The following environments commands are provided:
 
 - **tox -e style**: will check for coding style quality.
-- **tox -e py3X**: being X the minor version of your Python environment. Checks for unit tests.
-- **tox -e py3X-coverage**: checks for unit testing and code coverage.
+- **tox -e py**: checks for unit tests.
+- **tox -e py-coverage**: checks for unit testing and code coverage.
 - **tox -e doc**: checs for documentation building process.
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py: python3
     {style,doc,build}: python3
 passenv = *
 setenv =


### PR DESCRIPTION
When reviewing PyPIM docs, @PipKat was wondering if it was worth it to document how to find your python version to be able to run "tox -e py3X". It turns out that by default, tox provides an environment named "py" picking the current python version: https://tox.wiki/en/latest/config.html#tox-environments

This PR adds the same unversioned "py", and uses it in the `README`, under the assumption that by default, a developer just want to run the test with the current python version. The only variation from the default tox behavior is the selection of "python3" to avoid a fallback on python2 on some linux distrib.