### PR TITLE
Use official cookiecutter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "importlib-metadata >=4.0",
     "click>=7.0,<8.0.0",
-    "ansys-cookiecutter",
+    "cookiecutter>=2.1.0",
     "isort>=5.10.1",
 ]
 

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,2 +1,2 @@
-cookiecutter==1.7.3
+cookiecutter==2.1.0
 tox==3.25.0


### PR DESCRIPTION
`cookiecutter==2.1.0` is finally released see [pypi cookiecutter==2.1.0](https://pypi.org/project/cookiecutter/2.1.0/).

This PR updates the requirements accordingly.