### PR TITLE
Use MAIN_PYTHON_VERSION env var

### DIFF
--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.github/workflows/ci_cd.yml
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.github/workflows/ci_cd.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          python-version: {{ '${{ env.MAIN_PYTHON_VERSION }}' }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip {{ cookiecutter.__build_system }} tox
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          python-version: {{ '${{ env.MAIN_PYTHON_VERSION }}' }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip {{ cookiecutter.__build_system }} tox
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          python-version: {{ '${{ env.MAIN_PYTHON_VERSION }}' }}
       - name: Install dependencies and build the library
         run: |
           python -m pip install --upgrade pip {{ cookiecutter.__build_system }}

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.github/workflows/ci_cd.yml
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.github/workflows/ci_cd.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+env:
+  MAIN_PYTHON_VERSION: '{{ cookiecutter.__requires_python }}'
+
 jobs:
 
   style:
@@ -17,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: {{ cookiecutter.__requires_python }}
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip {{ cookiecutter.__build_system }} tox
@@ -81,7 +84,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: {{ cookiecutter.__requires_python }}
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip {{ cookiecutter.__build_system }} tox
@@ -97,7 +100,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: {{ cookiecutter.__requires_python }}
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
       - name: Install dependencies and build the library
         run: |
           python -m pip install --upgrade pip {{ cookiecutter.__build_system }}


### PR DESCRIPTION
As commented, force cookiecutter to implement the MAIN_PYTHON_VERSION variable so that mods only take place in one line,instead of in all `python-version` lines.