### PR TITLE
Fix requirements and include dependabot

### DIFF
--- a/requirements/requirements_build.txt
+++ b/requirements/requirements_build.txt
@@ -1,2 +1,2 @@
-build>=0.7.0
-twine>=3.8.0
+build==0.8.0
+twine==4.0.1

--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -1,4 +1,4 @@
-Sphinx>=4.4
-numpydoc>=1.2
-ansys_sphinx_theme>=0.4.0
-Sphinx-copybutton>=0.4
+Sphinx==5.0.2
+numpydoc==1.4.0
+ansys-sphinx-theme==0.4.2
+sphinx-copybutton==0.5

--- a/requirements/requirements_tests.txt
+++ b/requirements/requirements_tests.txt
@@ -1,2 +1,2 @@
-pytest>=7.1.1
-pytest-cov>=3.0.0
+pytest==7.1.2
+pytest-cov==3.0.0

--- a/src/ansys/templates/python/common/cookiecutter.json
+++ b/src/ansys/templates/python/common/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "__template_name": "",
   "__product_name_slug": "",
   "__library_name_slug": "",
   "__project_name_slug": "",

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.github/dependabot.yml
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    {%- if cookiecutter.__template_name in ["pybasic", "pyansys"] %}
+    directory: "/"
+    {%- else -%}
+    directory: "/requirements"
+    {%- endif -%}
+    schedule:
+      interval: "daily"
+    labels:
+      - "maintenance"
+      - "dependencies"

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/requirements_build.txt
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/requirements_build.txt
@@ -1,2 +1,2 @@
-build>=0.7.0
-twine>=3.8
+build==0.8.0
+twine==4.0.1

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/requirements_doc.txt
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/requirements_doc.txt
@@ -1,4 +1,4 @@
-Sphinx>=4.4
-numpydoc>=1.2
-ansys_sphinx_theme>=0.4.1
-Sphinx-copybutton>=0.4
+Sphinx==5.0.2
+numpydoc==1.4.0
+ansys-sphinx-theme==0.4.2
+sphinx-copybutton==0.5

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/requirements_tests.txt
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/requirements_tests.txt
@@ -1,2 +1,2 @@
-pytest>=7.1.0
-pytest-cov>=3.0.0
+pytest==7.1.2
+pytest-cov==3.0.0

--- a/src/ansys/templates/python/pyace_fastapi/cookiecutter.json
+++ b/src/ansys/templates/python/pyace_fastapi/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "__template_name": "pyace-fastapi",
   "project_name": "project",
   "__project_name_slug": "{{ cookiecutter.project_name | slugify(separator=('_')) }}",
   "library_name": "library",

--- a/src/ansys/templates/python/pyace_fastapi/hooks/post_gen_project.py
+++ b/src/ansys/templates/python/pyace_fastapi/hooks/post_gen_project.py
@@ -79,6 +79,7 @@ def main():
     if ci_cd == 'GitHub':
         DESIRED_STRUCTURE.extend(
             [
+                ".github/dependabot.yml",
                 ".github/labeler.yml",
                 ".github/labels.yml",
                 ".github/workflows/ci_cd.yml",

--- a/src/ansys/templates/python/pyace_flask/cookiecutter.json
+++ b/src/ansys/templates/python/pyace_flask/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "__template_name": "pyace-flask",
   "project_name": "project",
   "__project_name_slug": "{{ cookiecutter.project_name | slugify(separator=('_')) }}",
   "library_name": "library",

--- a/src/ansys/templates/python/pyace_flask/hooks/post_gen_project.py
+++ b/src/ansys/templates/python/pyace_flask/hooks/post_gen_project.py
@@ -84,6 +84,7 @@ def main():
     if ci_cd == 'GitHub':
         DESIRED_STRUCTURE.extend(
             [
+                ".github/dependabot.yml",
                 ".github/labeler.yml",
                 ".github/labels.yml",
                 ".github/workflows/ci_cd.yml",

--- a/src/ansys/templates/python/pyace_grpc/cookiecutter.json
+++ b/src/ansys/templates/python/pyace_grpc/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "__template_name": "pyace-grpc",
   "project_name": "project",
   "__project_name_slug": "{{ cookiecutter.project_name | slugify(separator=('_')) }}",
   "library_name": "library",

--- a/src/ansys/templates/python/pyace_grpc/hooks/post_gen_project.py
+++ b/src/ansys/templates/python/pyace_grpc/hooks/post_gen_project.py
@@ -82,6 +82,7 @@ def main():
     if ci_cd == 'GitHub':
         DESIRED_STRUCTURE.extend(
             [
+                ".github/dependabot.yml",
                 ".github/labeler.yml",
                 ".github/labels.yml",
                 ".github/workflows/ci_cd.yml",

--- a/src/ansys/templates/python/pyace_pkg/cookiecutter.json
+++ b/src/ansys/templates/python/pyace_pkg/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "__template_name": "pyace-pkg",
   "project_name": "project",
   "__project_name_slug": "{{ cookiecutter.project_name | slugify(separator=('_')) }}",
   "library_name": "library",

--- a/src/ansys/templates/python/pyace_pkg/hooks/post_gen_project.py
+++ b/src/ansys/templates/python/pyace_pkg/hooks/post_gen_project.py
@@ -76,6 +76,7 @@ def main():
     if ci_cd == 'GitHub':
         DESIRED_STRUCTURE.extend(
             [
+                ".github/dependabot.yml",
                 ".github/labeler.yml",
                 ".github/labels.yml",
                 ".github/workflows/ci_cd.yml",

--- a/src/ansys/templates/python/pyansys/cookiecutter.json
+++ b/src/ansys/templates/python/pyansys/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "__template_name": "pyansys",
   "product_name": "Product",
   "__product_name_slug": "{{ cookiecutter.product_name | slugify(separator=('_')) }}",
   "library_name": "Library",

--- a/src/ansys/templates/python/pyansys_advanced/cookiecutter.json
+++ b/src/ansys/templates/python/pyansys_advanced/cookiecutter.json
@@ -1,5 +1,5 @@
-
 {
+  "__template_name": "pyansys-advanced",
   "product_name": "product",
   "__product_name_slug": "{{ cookiecutter.product_name | slugify(separator=('_')) }}",
   "library_name": "library",

--- a/src/ansys/templates/python/pyansys_advanced/hooks/post_gen_project.py
+++ b/src/ansys/templates/python/pyansys_advanced/hooks/post_gen_project.py
@@ -27,6 +27,7 @@ DESIRED_STRUCTURE = [
     "doc/source/_templates/README.md",
     "examples/README.md",
     ".flake8",
+    ".github/dependabot.yml",
     ".github/labeler.yml",
     ".github/labels.yml",
     ".github/workflows/ci_cd.yml",

--- a/src/ansys/templates/python/pyansys_openapi_client/cookiecutter.json
+++ b/src/ansys/templates/python/pyansys_openapi_client/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "__template_name": "pyansys-openapi-client",
   "product_name": "product",
   "__product_name_slug": "{{ cookiecutter.product_name | slugify(separator=('_')) }}",
   "library_name": "library",

--- a/src/ansys/templates/python/pybasic/cookiecutter.json
+++ b/src/ansys/templates/python/pybasic/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "__template_name": "pybasic",
   "project_name": "",
   "__project_name_slug": "{{ cookiecutter.project_name | slugify(separator=('_')) }}",
   "version": "0.1.dev0",

--- a/tests/tests_templates/test_python_templates.py
+++ b/tests/tests_templates/test_python_templates.py
@@ -52,6 +52,7 @@ PYACE_VARS = dict(
 PYCOMMON_STRUCTURE = [
     ".coveragerc",
     ".flake8",
+    ".github/dependabot.yml",
     ".github/labeler.yml",
     ".github/labels.yml",
     ".github/workflows/ci_cd.yml",
@@ -91,13 +92,13 @@ PYBASIC_STRUCTURE = deepcopy(PYCOMMON_STRUCTURE) + [
     f"src/{PYBASIC_VARS['project_name']}/__init__.py",
 ]
 [PYBASIC_STRUCTURE.remove(file) for file in
- [".github/labeler.yml", ".github/labels.yml", ".github/workflows/label.yml", ".github/workflows/ci_cd.yml", ".pre-commit-config.yaml", "azure-pipeline.yml", "tox.ini"]]
+ [".github/dependabot.yml", ".github/labeler.yml", ".github/labels.yml", ".github/workflows/label.yml", ".github/workflows/ci_cd.yml", ".pre-commit-config.yaml", "azure-pipeline.yml", "tox.ini"]]
 
 # Structure for pyansys projects
 PYANSYS_STRUCTURE = deepcopy(PYCOMMON_STRUCTURE) + [
     f"src/ansys/{PYANSYS_VARS['__product_name_slug']}/{PYANSYS_VARS['__library_name_slug']}/__init__.py",
 ]
-[PYANSYS_STRUCTURE.remove(file) for file in [".github/labeler.yml", ".github/labels.yml", ".github/workflows/label.yml", ".github/workflows/ci_cd.yml", "azure-pipeline.yml", "tox.ini"]]
+[PYANSYS_STRUCTURE.remove(file) for file in [".github/dependabot.yml", ".github/labeler.yml", ".github/labels.yml", ".github/workflows/label.yml", ".github/workflows/ci_cd.yml", "azure-pipeline.yml", "tox.ini"]]
 
 # Structure for pyansys-advanced projects
 PYANSYS_ADVANCED_STRUCTURE = deepcopy(PYCOMMON_STRUCTURE) + [


### PR DESCRIPTION
Fixing requirements is the best way for making sure dependabot opens keeps requirements up to date.

Also, this PR implements this bot in the modern templates.