### PR TITLE
Remove outdated flit sdist section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,6 @@ dependencies = [
 [tool.flit.module]
 name = "ansys.templates"
 
-[tool.flit.sdist]
-include = ["src/ansys/templates/pypkg/"]
-
 [project.scripts]
 ansys-templates = "ansys.templates.cli:main"
 


### PR DESCRIPTION
Just noticed this outdated section in the `pyproject.toml` file. From [flit docs](https://flit.pypa.io/en/latest/pyproject_toml.html#sdist-section):

> When you use [flit build](https://flit.pypa.io/en/latest/cmdline.html#build-cmd) or [flit publish](https://flit.pypa.io/en/latest/cmdline.html#publish-cmd), Flit builds an sdist (source distribution) tarball containing the files that are checked into version control (git or mercurial).

Checked locally and all required files are being included in the sdist.