### PR TITLE
Revert "Build(deps): Bump codecov/codecov-action from 3 to 4 (#352)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         run: tox -e ${{ matrix.cfg.toxenv }}-smoke-cov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         if: matrix.cfg.python-version ==  ${{ env.MAIN_PYTHON_VERSION }}
 
   build-library:


### PR DESCRIPTION
This reverts commit f3a1c5c4254fbe6db540b9dffaa27366677d1800.

Because CI is failing to find v4 action.

## References:
* https://github.com/ansys/ansys-templates/actions/runs/7274749844/job/19821410675?pr=417#step:1:35
* https://github.com/ansys/ansys-templates/commit/f3a1c5c4254fbe6db540b9dffaa27366677d1800#commitcomment-135415380
* https://github.com/codecov/codecov-action/releases