### PR TITLE
tweak: use standard flit dev dependency extra name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-tests = [
+test = [
     "pytest==7.4.3",
     "pytest-cov==4.1.0",
 ]

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/pyproject.toml
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-tests = [
+test = [
     "pytest==7.3.0",
     "pytest-cov==4.0.0",
 ]

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/tox.ini
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/tox.ini
@@ -33,7 +33,7 @@ deps =
     -r{toxinidir}/requirements/requirements_tests.txt
 {%- elif cookiecutter.__build_system == "flit" %}
 extras =
-    tests
+    test
 {%- endif %}
 setenv =
     PYTHONUNBUFFERED = yes

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ setenv =
     cov: PYTEST_EXTRA_ARGS = --cov=ansys.templates --cov-report=term --cov-report=xml:.cov/xml --cov-report=html:.cov/html
 skip_install = false
 extras =
-    tests
+    test
 commands =
     pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs: tests -vvv}
 


### PR DESCRIPTION
`flit install --deps develop` uses the extra names `test`, `doc` and `dev`. 
This changes the template and the main pyproject to respect that.

https://flit.pypa.io/en/stable/cmdline.html#cmdoption-flit-install-deps